### PR TITLE
[DX]: Basic issue templates added for better contributing experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: 🐞 Bug
+description: Report an issue to help improve the project.
+title: "Bug: Write a small description here"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Write a detailed description of the issue that you faced.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Write a solution which you think can fix this issue.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots/videos if applicable
+    validations:
+      required: false
+  
+  - type: dropdown
+    id: browser
+    attributes:
+      label: "Browser 🥦"
+      description: "What browser are you using ?"
+      options:
+        - Google Chrome
+        - Brave
+        - Microsoft Edge
+        - Mozilla Firefox
+        - Safari
+        - Opera
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "Checklist ✅"
+      options:
+        - label: "I checked and didn't find similar [issue](https://github.com/hoichoi-opensource/imageresizer/issues)"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/hoichoi-opensource/imageresizer/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)."
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,48 @@
+name: 📄 Documentation issue
+description: Found an issue in the documentation? You can use this one!
+title: "Docs: Write a small description here"
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Write a detailed description of the changes you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots/videos if applicable
+    validations:
+      required: false
+  - type: dropdown
+    id: browser
+    attributes:
+      label: "🥦 Browser"
+      description: "What browser are you using ?"
+      options:
+        - Google Chrome
+        - Brave
+        - Microsoft Edge
+        - Mozilla Firefox
+        - Safari
+        - Opera
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "Checklist ✅"
+      options:
+        - label: "I checked and didn't find similar [issue](https://github.com/hoichoi-opensource/imageresizer/issues)"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/hoichoi-opensource/imageresizer/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)"
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+  name: 💡 Feature Request
+  description: Have a new idea/feature ? Please suggest!
+  title: "Feature: Write a small description here"
+  labels: ["enhancement"]
+  body:
+    - type: textarea
+      id: description
+      attributes:
+        label: Description
+        description: Write a detailed description of the feature you propose.
+      validations:
+        required: true
+    - type: textarea
+      id: solution
+      attributes:
+        label: Proposed Solution
+        description: What needs to be done to implement this feature?
+      validations:
+        required: true
+    - type: textarea
+      id: screenshots
+      attributes:
+        label: Screenshots
+        description: Please add screenshots/videos if applicable
+      validations:
+        required: false
+    
+    - type: dropdown
+      id: browser
+      attributes:
+        label: "🥦 Browser"
+        description: "What browser are you using ?"
+        options:
+          - Google Chrome
+          - Brave
+          - Microsoft Edge
+          - Mozilla Firefox
+          - Safari
+          - Opera
+          - Other
+      validations:
+        required: true
+
+    - type: checkboxes
+      id: no-duplicate-issues
+      attributes:
+        label: "Checklist ✅"
+        options:
+          - label: "I checked and didn't find similar [issue](https://github.com/hoichoi-opensource/imageresizer/issues)"
+            required: true
+
+          - label: "I have read the [Contributing Guidelines](https://github.com/hoichoi-opensource/imageresizer/blob/main/CONTRIBUTING.md)"
+            required: true
+
+          - label: "I am willing to work on this issue (blank for no)"
+            required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,40 @@
+name: Other
+description: Use this for any other issues. Please do NOT create blank issues
+title: "📂Other: Write a small description here"
+body:
+  - type: textarea
+    id: issuedescription
+    attributes:
+      label: What would you like to share?
+      description: Provide a clear and concise explanation of your issue.
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: "🥦 Browser"
+      description: "What browser are you using ?"
+      options:
+        - Google Chrome
+        - Brave
+        - Microsoft Edge
+        - Mozilla Firefox
+        - Safari
+        - Opera
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "Checklist ✅"
+      options:
+        - label: "I checked and didn't find similar [issue](https://github.com/hoichoi-opensource/imageresizer/issues)"
+          required: true
+
+        - label: "I have read the [Contributing Guidelines](https://github.com/hoichoi-opensource/imageresizer/blob/main/CONTRIBUTING.md)"
+          required: true
+
+        - label: "I am willing to work on this issue (blank for no)"
+          required: false


### PR DESCRIPTION
The issue templates have been added, please check it out in my [forked version](https://github.com/tamalCodes/imageresizer/issues/new/choose) until this is merged. I have set the `blank_issues_enabled` to false as a result there won't be any blank issues.